### PR TITLE
Add match v5 endpoints

### DIFF
--- a/__tests__/e2e/match_v5.test.ts
+++ b/__tests__/e2e/match_v5.test.ts
@@ -1,0 +1,25 @@
+jest.unmock("@fightmegg/riot-rate-limiter");
+
+import { count } from "console";
+import "jest-extended";
+import { PlatformId, RiotAPI } from "../../src/index";
+
+const riotAPIKey = process.env.X_RIOT_API_KEY || "";
+
+describe("E2E", () => {
+  describe("Match V5", () => {
+    test("getIdsbyPuuid", async () => {
+      const rAPI = new RiotAPI(riotAPIKey);
+
+      const resp = await rAPI.matchV5.getIdsbyPuuid({
+        cluster: PlatformId.EUROPE,
+        puuid: "iGWKyE9MjG-aUw0KaYRvH4V2iEZwM14fbDr4Qlx0JVLOzlMqSbmQWpfbOsJPFK_dZabRH9cP7kqz5g",
+        params: {
+          start: 0,
+          count: 5
+        }
+      });
+      expect(resp).toHaveLength(5)
+    });
+  });
+});

--- a/__tests__/e2e/match_v5.test.ts
+++ b/__tests__/e2e/match_v5.test.ts
@@ -34,8 +34,46 @@ describe("E2E", () => {
       expect(resp).toContainAllKeys([
         "metadata",
         "info"
-      ])
-      expect(resp.metadata.matchId).toEqual(matchId)
+      ]);
+      expect(resp.info).toContainAllKeys([
+        "gameCreation",
+        "gameDuration",
+        "gameId",
+        "gameMode",
+        "gameName",
+        "gameStartTimestamp",
+        "gameType",
+        "gameVersion",
+        "mapId",
+        "participants",
+        "platformId",
+        "queueId",
+        "teams",
+        "tournamentCode",
+      ]);
+      expect(resp.metadata.matchId).toEqual(matchId);
+    });
+
+    test("getMatchTimelineById", async () => {
+      const rAPI = new RiotAPI(riotAPIKey);
+
+      const matchId = "EUW1_5350514472"
+
+      const resp = await rAPI.matchV5.getMatchTimelineById({
+        cluster: PlatformId.EUROPE,
+        matchId,
+      });
+      expect(resp).toContainAllKeys([
+        "metadata",
+        "info",
+      ]);
+      expect(resp.info).toContainAnyKeys([
+        "frameInterval",
+        "frames",
+        "gameId",
+        "participants",
+      ]);
+      expect(resp.metadata.matchId).toEqual(matchId);
     });
   });
 });

--- a/__tests__/e2e/match_v5.test.ts
+++ b/__tests__/e2e/match_v5.test.ts
@@ -13,28 +13,26 @@ describe("E2E", () => {
 
       const resp = await rAPI.matchV5.getIdsbyPuuid({
         cluster: PlatformId.EUROPE,
-        puuid: "iGWKyE9MjG-aUw0KaYRvH4V2iEZwM14fbDr4Qlx0JVLOzlMqSbmQWpfbOsJPFK_dZabRH9cP7kqz5g",
+        puuid:
+          "8bJQbDi6uFIgefQA6Y79yxff_1bCHNopb1eHlq3p7Ic2oeXgYTvNnfGahtWyJ6qqAue3uK6wiZmMWQ",
         params: {
           start: 0,
-          count: 5
-        }
+          count: 5,
+        },
       });
-      expect(resp).toHaveLength(5)
+      expect(resp).toHaveLength(5);
     });
 
     test("getMatchById", async () => {
       const rAPI = new RiotAPI(riotAPIKey);
 
-      const matchId = "EUW1_5350514472"
+      const matchId = "EUW1_5350514472";
 
       const resp = await rAPI.matchV5.getMatchById({
         cluster: PlatformId.EUROPE,
         matchId,
       });
-      expect(resp).toContainAllKeys([
-        "metadata",
-        "info"
-      ]);
+      expect(resp).toContainAllKeys(["metadata", "info"]);
       expect(resp.info).toContainAllKeys([
         "gameCreation",
         "gameDuration",
@@ -57,16 +55,13 @@ describe("E2E", () => {
     test("getMatchTimelineById", async () => {
       const rAPI = new RiotAPI(riotAPIKey);
 
-      const matchId = "EUW1_5350514472"
+      const matchId = "EUW1_5350514472";
 
       const resp = await rAPI.matchV5.getMatchTimelineById({
         cluster: PlatformId.EUROPE,
         matchId,
       });
-      expect(resp).toContainAllKeys([
-        "metadata",
-        "info",
-      ]);
+      expect(resp).toContainAllKeys(["metadata", "info"]);
       expect(resp.info).toContainAnyKeys([
         "frameInterval",
         "frames",

--- a/__tests__/e2e/match_v5.test.ts
+++ b/__tests__/e2e/match_v5.test.ts
@@ -21,5 +21,21 @@ describe("E2E", () => {
       });
       expect(resp).toHaveLength(5)
     });
+
+    test("getMatchById", async () => {
+      const rAPI = new RiotAPI(riotAPIKey);
+
+      const matchId = "EUW1_5350514472"
+
+      const resp = await rAPI.matchV5.getMatchById({
+        cluster: PlatformId.EUROPE,
+        matchId,
+      });
+      expect(resp).toContainAllKeys([
+        "metadata",
+        "info"
+      ])
+      expect(resp.metadata.matchId).toEqual(matchId)
+    });
   });
 });

--- a/__tests__/unit/index.test.ts
+++ b/__tests__/unit/index.test.ts
@@ -806,6 +806,21 @@ describe("RiotAPI", () => {
           },
         ],
       ],
+      [
+        "getMatchById",
+        {
+          cluster: PlatformId.EUROPE,
+          matchId: "123",
+        },
+        [
+          PlatformId.EUROPE,
+          RiotAPITypes.METHOD_KEY.MATCH_V5.GET_MATCH_BY_ID,
+          { matchId: "123" },
+          {
+            id: `${PlatformId.EUROPE}.matchv5.getMatchById.123`,
+          },
+        ],
+      ],
     ])(
       "%s - calls request with correct params",
       async (name, input, params) => {

--- a/__tests__/unit/index.test.ts
+++ b/__tests__/unit/index.test.ts
@@ -821,6 +821,21 @@ describe("RiotAPI", () => {
           },
         ],
       ],
+      [
+        "getMatchTimelineById",
+        {
+          cluster: PlatformId.EUROPE,
+          matchId: "123",
+        },
+        [
+          PlatformId.EUROPE,
+          RiotAPITypes.METHOD_KEY.MATCH_V5.GET_MATCH_TIMELINE_BY_ID,
+          { matchId: "123" },
+          {
+            id: `${PlatformId.EUROPE}.matchv5.getMatchTimelineById.123`,
+          },
+        ],
+      ],
     ])(
       "%s - calls request with correct params",
       async (name, input, params) => {

--- a/__tests__/unit/index.test.ts
+++ b/__tests__/unit/index.test.ts
@@ -762,6 +762,62 @@ describe("RiotAPI", () => {
     );
   });
 
+  describe("match_v5", () => {
+    test.each([
+      [
+        "getIdsbyPuuid",
+        {
+          cluster: PlatformId.EUROPE,
+          puuid: "uuid",
+        },
+        [
+          PlatformId.EUROPE,
+          RiotAPITypes.METHOD_KEY.MATCH_V5.GET_IDS_BY_PUUID,
+          { puuid: "uuid" },
+          {
+            id: `${PlatformId.EUROPE}.matchv5.getIdsByPuuid.uuid`,
+          },
+        ],
+      ],
+      [
+        "getIdsbyPuuid",
+        {
+          cluster: PlatformId.EUROPE,
+          puuid: "uuid",
+          params: {
+            queue: 1,
+            type: RiotAPITypes.MatchV5.MatchType.Ranked,
+            start: 0,
+            count: 20,
+          }
+        },
+        [
+          PlatformId.EUROPE,
+          RiotAPITypes.METHOD_KEY.MATCH_V5.GET_IDS_BY_PUUID,
+          { puuid: "uuid" },
+          {
+            id: `${PlatformId.EUROPE}.matchv5.getIdsByPuuid.uuid`,
+            params: {
+              queue: 1,
+              type: RiotAPITypes.MatchV5.MatchType.Ranked,
+              start: 0,
+              count: 20,
+            }
+          },
+        ],
+      ],
+    ])(
+      "%s - calls request with correct params",
+      async (name, input, params) => {
+        const rAPI = new RiotAPI("1234");
+        rAPI.request = jest.fn().mockResolvedValue(null);
+
+        await getKeyValue(rAPI.matchV5)(name as any)(input as any);
+        expect(rAPI.request).toHaveBeenCalledWith(...params);
+      }
+    );
+  })
+
   describe("spectator", () => {
     test.each([
       [

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -151,7 +151,8 @@ export namespace RiotAPITypes {
     export namespace MATCH_V5 {
       export const GET_IDS_BY_PUUID = "MATCH_V5.GET_IDS_BY_PUUID";
       export const GET_MATCH_BY_ID = "MATCH_V5.GET_MATCH_BY_ID";
-      export const GET_MATCH_TIMELINE_BY_ID = "MATCH_V5.GET_MATCH_TIMELINE_BY_ID";
+      export const GET_MATCH_TIMELINE_BY_ID =
+        "MATCH_V5.GET_MATCH_TIMELINE_BY_ID";
     }
     export namespace SPECTATOR {
       export const GET_GAME_BY_SUMMONER_ID =
@@ -759,10 +760,10 @@ export namespace RiotAPITypes {
 
   export namespace MatchV5 {
     export enum MatchType {
-       Ranked = "ranked",
-       Normal = "normal",
-       Tourney = "tourney",
-       Tutorial = "tutorial",
+      Ranked = "ranked",
+      Normal = "normal",
+      Tourney = "tourney",
+      Tutorial = "tutorial",
     }
 
     export interface StatPerksDTO {
@@ -772,23 +773,21 @@ export namespace RiotAPITypes {
     }
 
     export interface SelectionDTO {
-        perk: number;
-        var1: number;
-        var2: number;
-        var3: number;
+      perk: number;
+      var1: number;
+      var2: number;
+      var3: number;
     }
 
     export interface StyleDTO {
-        description: string;
-        selections: SelectionDTO[];
-        style: number;
+      description: string;
+      selections: SelectionDTO[];
+      style: number;
     }
 
     export interface PerksDTO {
-        statPerks: StatPerksDTO;
-        styles: StyleDTO[];
-
-
+      statPerks: StatPerksDTO;
+      styles: StyleDTO[];
     }
 
     export interface ParticipantDTO {
@@ -941,7 +940,7 @@ export namespace RiotAPITypes {
       tournamentCode: string;
     }
 
-    export interface MetadataDTO { 
+    export interface MetadataDTO {
       dataVersion: string;
       matchId: string;
       participants: string[];

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -764,6 +764,193 @@ export namespace RiotAPITypes {
        Tourney = "tourney",
        Tutorial = "tutorial",
     }
+
+    export interface StatPerksDTO {
+      defense: number;
+      flex: number;
+      offense: number;
+    }
+
+    export interface SelectionDTO {
+        perk: number;
+        var1: number;
+        var2: number;
+        var3: number;
+    }
+
+    export interface StyleDTO {
+        description: string;
+        selections: SelectionDTO[];
+        style: number;
+    }
+
+    export interface PerksDTO {
+        statPerks: StatPerksDTO;
+        styles: StyleDTO[];
+
+
+    }
+
+    export interface ParticipantDTO {
+      assists: number;
+      baronKills: number;
+      bountyLevel: number;
+      champExperience: number;
+      champLevel: number;
+      championId: number;
+      championName: string;
+      championTransform: number;
+      consumablesPurchased: number;
+      damageDealtToBuildings: number;
+      damageDealtToObjectives: number;
+      damageDealtToTurrets: number;
+      damageSelfMitigated: number;
+      deaths: number;
+      detectorWardsPlaced: number;
+      doubleKills: number;
+      dragonKills: number;
+      firstBloodAssist: boolean;
+      firstBloodKill: boolean;
+      firstTowerAssist: boolean;
+      firstTowerKill: boolean;
+      gameEndedInEarlySurrender: boolean;
+      gameEndedInSurrender: boolean;
+      goldEarned: number;
+      goldSpent: number;
+      individualPosition: string;
+      inhibitorKills: number;
+      inhibitorTakedowns: number;
+      inhibitorsLost: number;
+      item0: number;
+      item1: number;
+      item2: number;
+      item3: number;
+      item4: number;
+      item5: number;
+      item6: number;
+      itemsPurchased: number;
+      killingSprees: number;
+      kills: number;
+      lane: string;
+      largestCriticalStrike: number;
+      largestKillingSpree: number;
+      largestMultiKill: number;
+      longestTimeSpentLiving: number;
+      magicDamageDealt: number;
+      magicDamageDealtToChampions: number;
+      magicDamageTaken: number;
+      neutralMinionsKilled: number;
+      nexusKills: number;
+      nexusLost: number;
+      nexusTakedowns: number;
+      objectivesStolen: number;
+      objectivesStolenAssists: number;
+      participantId: number;
+      pentaKills: number;
+      perks: PerksDTO;
+      physicalDamageDealt: number;
+      physicalDamageDealtToChampions: number;
+      physicalDamageTaken: number;
+      profileIcon: number;
+      puuid: string;
+      quadraKills: number;
+      riotIdName: string;
+      riotIdTagline: string;
+      role: string;
+      sightWardsBoughtInGame: number;
+      spell1Casts: number;
+      spell2Casts: number;
+      spell3Casts: number;
+      spell4Casts: number;
+      summoner1Casts: number;
+      summoner1Id: number;
+      summoner2Casts: number;
+      summoner2Id: number;
+      summonerId: string;
+      summonerLevel: number;
+      summonerName: string;
+      teamEarlySurrendered: boolean;
+      teamId: number;
+      teamPosition: string;
+      timeCCingOthers: number;
+      timePlayed: number;
+      totalDamageDealt: number;
+      totalDamageDealtToChampions: number;
+      totalDamageShieldedOnTeammates: number;
+      totalDamageTaken: number;
+      totalHeal: number;
+      totalHealsOnTeammates: number;
+      totalMinionsKilled: number;
+      totalTimeCCDealt: number;
+      totalTimeSpentDead: number;
+      totalUnitsHealed: number;
+      tripleKills: number;
+      trueDamageDealt: number;
+      trueDamageDealtToChampions: number;
+      trueDamageTaken: number;
+      turretKills: number;
+      turretTakedowns: number;
+      turretsLost: number;
+      unrealKills: number;
+      visionScore: number;
+      visionWardsBoughtInGame: number;
+      wardsKilled: number;
+      wardsPlaced: number;
+      win: boolean;
+    }
+
+    export interface ObjectivesStatsDTO {
+      first: boolean;
+      kills: number;
+    }
+    export interface ObjectivesDTO {
+      baron: ObjectivesStatsDTO;
+      champion: ObjectivesStatsDTO;
+      dragon: ObjectivesStatsDTO;
+      inhibitor: ObjectivesStatsDTO;
+      riftHerald: ObjectivesStatsDTO;
+      tower: ObjectivesStatsDTO;
+    }
+
+    export interface BanDTO {
+      championId: number;
+      pickTurn: number;
+    }
+
+    export interface TeamDTO {
+      bans: BanDTO[];
+      objectives: ObjectivesDTO;
+      teamId: number;
+      win: boolean;
+    }
+
+    export interface MatchInfoDTO {
+      gameCreation: number;
+      gameDuration: number;
+      gameId: number;
+      gameMode: string;
+      gameName: string;
+      gameStartTimestamp: number;
+      gameType: string;
+      gameVersion: string;
+      mapId: number;
+      participants: ParticipantDTO[];
+      platformId: string;
+      queueId: number;
+      teams: TeamDTO[];
+      tournamentCode: string;
+    }
+
+    export interface MetadataDTO { 
+      dataVersion: string;
+      matchId: string;
+      participants: string[];
+    }
+
+    export interface MatchDTO {
+      metadata: MetadataDTO;
+      info: MatchInfoDTO;
+    }
   }
 
   export namespace Spectator {

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -151,7 +151,7 @@ export namespace RiotAPITypes {
     export namespace MATCH_V5 {
       export const GET_IDS_BY_PUUID = "MATCH_V5.GET_IDS_BY_PUUID";
       export const GET_MATCH_BY_ID = "MATCH_V5.GET_MATCH_BY_ID";
-      export const GET_MATCH_TIMELINE_BY_ID = "MATCH.GET_MATCH_TIMELINE_BY_ID";
+      export const GET_MATCH_TIMELINE_BY_ID = "MATCH_V5.GET_MATCH_TIMELINE_BY_ID";
     }
     export namespace SPECTATOR {
       export const GET_GAME_BY_SUMMONER_ID =
@@ -950,6 +950,97 @@ export namespace RiotAPITypes {
     export interface MatchDTO {
       metadata: MetadataDTO;
       info: MatchInfoDTO;
+    }
+
+    export interface MatchTimelineParticipantDTO {
+      participantId: number;
+      puuid: string;
+    }
+
+    export interface PositionDTO {
+      x: number;
+      y: number;
+    }
+
+    export interface ParticipantFrameDTO {
+      championStats: { [key: string]: number };
+      currentGold: number;
+      damageStats: { [key: string]: number };
+      goldPerSecond: number;
+      jungleMinionsKilled: number;
+      level: number;
+      minionsKilled: number;
+      participantId: number;
+      position: PositionDTO;
+      timeEnemySpentControlled: number;
+      totalGold: number;
+      xp: number;
+    }
+
+    export interface VictimDamageDTO {
+      basic: boolean;
+      magicDamage: number;
+      name: string;
+      participantId: number;
+      physicalDamage: number;
+      spellName: string;
+      spellSlot: number;
+      trueDamage: number;
+      type: string;
+    }
+
+    export interface EventDTO {
+      realTimestamp?: number;
+      timestamp: number;
+      type: string;
+      itemId?: number;
+      participantId?: number;
+      levelUpType?: string;
+      skillSlot?: number;
+      creatorId?: number;
+      wardType?: string;
+      level?: number;
+      bounty?: number;
+      killStreakLength?: number;
+      killerId?: number;
+      position?: PositionDTO;
+      victimDamageDealt?: string[];
+      victimDamageReceived?: string[];
+      victimId?: number;
+      killType?: string;
+      afterId?: number;
+      beforeId?: number;
+      goldGain?: number;
+      assistingParticipantIds?: number[];
+      laneType?: string;
+      teamId?: number;
+      killerTeamId?: number;
+      monsterSubType?: string;
+      monsterType?: string;
+      buildingType?: string;
+      towerType?: string;
+      transformType?: string;
+      multiKillLength?: number;
+      gameId?: number;
+      winningTeam?: number;
+    }
+
+    export interface FrameDTO {
+      events: EventDTO[];
+      participantFrames: { [key: string]: ParticipantFrameDTO };
+      timestamp: number;
+    }
+
+    export interface MatchTimelineInfoDTO {
+      frameInterval: number;
+      frames: FrameDTO[];
+      gameId: number;
+      participants: MatchTimelineParticipantDTO[];
+    }
+
+    export interface MatchTimelineDTO {
+      metadata: MetadataDTO;
+      info: MatchTimelineInfoDTO;
     }
   }
 

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -148,6 +148,11 @@ export namespace RiotAPITypes {
       export const GET_MATCHLIST_BY_ACCOUNT = "MATCH.GET_MATCHLIST_BY_ACCOUNT";
       export const GET_TIMELINE_BY_MATCH_ID = "MATCH.GET_TIMELINE_BY_MATCH_ID";
     }
+    export namespace MATCH_V5 {
+      export const GET_IDS_BY_PUUID = "MATCH_V5.GET_IDS_BY_PUUID";
+      export const GET_MATCH_BY_ID = "MATCH_V5.GET_MATCH_BY_ID";
+      export const GET_MATCH_TIMELINE_BY_ID = "MATCH.GET_MATCH_TIMELINE_BY_ID";
+    }
     export namespace SPECTATOR {
       export const GET_GAME_BY_SUMMONER_ID =
         "SPECTATOR.GET_GAME_BY_SUMMONER_ID";
@@ -749,6 +754,15 @@ export namespace RiotAPITypes {
       assistingParticipantIds?: number[] | null;
       buildingType?: string | null;
       victimId?: number | null;
+    }
+  }
+
+  export namespace MatchV5 {
+    export enum MatchType {
+       Ranked = "ranked",
+       Normal = "normal",
+       Tourney = "tourney",
+       Tutorial = "tutorial",
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -589,22 +589,22 @@ export class RiotAPI {
         puuid,
         params,
       }: {
-        cluster: RiotAPITypes.Cluster,
-        puuid: string,
+        cluster: RiotAPITypes.Cluster;
+        puuid: string;
         params?: {
-          queue?: number,
-          type?: RiotAPITypes.MatchV5.MatchType,
-          start?: number,
-          count?: number,
-        }
+          queue?: number;
+          type?: RiotAPITypes.MatchV5.MatchType;
+          start?: number;
+          count?: number;
+        };
       }): Promise<string[]> =>
         this.request(
           cluster,
           RiotAPITypes.METHOD_KEY.MATCH_V5.GET_IDS_BY_PUUID,
           { puuid },
-          { 
+          {
             id: `${cluster}.matchv5.getIdsByPuuid.${puuid}`,
-            params
+            params,
           }
         ),
       getMatchById: ({
@@ -612,13 +612,13 @@ export class RiotAPI {
         matchId,
       }: {
         cluster: RiotAPITypes.Cluster;
-        matchId: string
+        matchId: string;
       }): Promise<RiotAPITypes.MatchV5.MatchDTO> =>
         this.request(
           cluster,
           RiotAPITypes.METHOD_KEY.MATCH_V5.GET_MATCH_BY_ID,
           { matchId },
-          { 
+          {
             id: `${cluster}.matchv5.getMatchById.${matchId}`,
           }
         ),
@@ -627,17 +627,17 @@ export class RiotAPI {
         matchId,
       }: {
         cluster: RiotAPITypes.Cluster;
-        matchId: string
+        matchId: string;
       }): Promise<RiotAPITypes.MatchV5.MatchTimelineDTO> =>
         this.request(
           cluster,
           RiotAPITypes.METHOD_KEY.MATCH_V5.GET_MATCH_TIMELINE_BY_ID,
           { matchId },
-          { 
+          {
             id: `${cluster}.matchv5.getMatchTimelineById.${matchId}`,
           }
         ),
-    }
+    };
   }
 
   get spectator() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -582,6 +582,35 @@ export class RiotAPI {
     };
   }
 
+  // To do: params
+  get matchV5() {
+    return {
+      getIdsbyPuuid: ({
+        cluster,
+        puuid,
+        params,
+      }: {
+        cluster: RiotAPITypes.Cluster;
+        puuid: string;
+        params?: {
+          queue?: number,
+          type?: RiotAPITypes.MatchV5.MatchType,
+          start?: number,
+          count?: number,
+        }
+      }): Promise<string[]> =>
+        this.request(
+          cluster,
+          RiotAPITypes.METHOD_KEY.MATCH_V5.GET_IDS_BY_PUUID,
+          { puuid },
+          { 
+            id: `${cluster}.matchv5.getIdsByPuuid.${puuid}`,
+            params
+          }
+        ),
+    }
+  }
+
   get spectator() {
     return {
       getBySummonerId: ({

--- a/src/index.ts
+++ b/src/index.ts
@@ -582,7 +582,6 @@ export class RiotAPI {
     };
   }
 
-  // To do: params
   get matchV5() {
     return {
       getIdsbyPuuid: ({
@@ -590,8 +589,8 @@ export class RiotAPI {
         puuid,
         params,
       }: {
-        cluster: RiotAPITypes.Cluster;
-        puuid: string;
+        cluster: RiotAPITypes.Cluster,
+        puuid: string,
         params?: {
           queue?: number,
           type?: RiotAPITypes.MatchV5.MatchType,
@@ -606,6 +605,21 @@ export class RiotAPI {
           { 
             id: `${cluster}.matchv5.getIdsByPuuid.${puuid}`,
             params
+          }
+        ),
+      getMatchById: ({
+        cluster,
+        matchId,
+      }: {
+        cluster: RiotAPITypes.Cluster;
+        matchId: string
+      }): Promise<RiotAPITypes.MatchV5.MatchDTO> =>
+        this.request(
+          cluster,
+          RiotAPITypes.METHOD_KEY.MATCH_V5.GET_MATCH_BY_ID,
+          { matchId },
+          { 
+            id: `${cluster}.matchv5.getMatchById.${matchId}`,
           }
         ),
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -622,6 +622,21 @@ export class RiotAPI {
             id: `${cluster}.matchv5.getMatchById.${matchId}`,
           }
         ),
+      getMatchTimelineById: ({
+        cluster,
+        matchId,
+      }: {
+        cluster: RiotAPITypes.Cluster;
+        matchId: string
+      }): Promise<RiotAPITypes.MatchV5.MatchTimelineDTO> =>
+        this.request(
+          cluster,
+          RiotAPITypes.METHOD_KEY.MATCH_V5.GET_MATCH_TIMELINE_BY_ID,
+          { matchId },
+          { 
+            id: `${cluster}.matchv5.getMatchTimelineById.${matchId}`,
+          }
+        ),
     }
   }
 


### PR DESCRIPTION
# Context
As described [here](https://developer.riotgames.com/apis#match-v5) 
> match-v4 is being deprecated on Monday, July 26th, 2021. Please use match-v5 as a replacement. match-v5 is available on Development API keys as of April 14th, production access will follow starting in early June.
> 
> The match and timeline responses are not 100% locked. There may be minor field changes, which will be documented in the method details. We'll make our best effort to extend the deprecation window if any changes happen after match-v5 becomes available for production API keys.

# Changes
- Added 3 match V5 endpoints (DTO + unit and e2e tests)
  - getIdsbyPuuid
  - getMatchById
  - getMatchTimelineById