### PR TITLE
Adapt DDragon images interfaces

### DIFF
--- a/__tests__/e2e/ddragon.test.ts
+++ b/__tests__/e2e/ddragon.test.ts
@@ -1,4 +1,4 @@
-import { DDragon, RiotAPI } from "../../src/index";
+import { DDragon, RiotAPI, RiotAPITypes } from "../../src/index";
 
 describe("E2E", () => {
   describe("DDragon", () => {
@@ -9,10 +9,40 @@ describe("E2E", () => {
         const aatrox = await ddragon.champion.byName({
           championName: "Aatrox",
         });
+
+        const aatroxImage: RiotAPITypes.DDragon.DDragonImageDTO = {
+          full: "Aatrox.png",
+          sprite: "champion0.png",
+          group: "champion",
+          x: 0,
+          y: 0,
+          w: 48,
+          h: 48,
+        };
+
         expect(aatrox.type).toEqual("champion");
         expect(aatrox.format).toEqual("standAloneComplex");
         expect(aatrox.data.Aatrox.id).toEqual("Aatrox");
+        expect(aatrox.data.Aatrox.image).toEqual(aatroxImage);
       });
+    });
+
+    test("profileIcons", async () => {
+      const ddragon = new DDragon();
+      const profileIcons = await ddragon.profileIcons();
+      const profilIcon: RiotAPITypes.DDragon.DDragonImageWrapperDTO = {
+        id: 1000,
+        image: {
+          full: "1000.png",
+          sprite: "profileicon0.png",
+          group: "profileicon",
+          x: 96,
+          y: 0,
+          w: 48,
+          h: 48,
+        },
+      };
+      expect(profileIcons.data["1000"]).toEqual(profilIcon);
     });
   });
 
@@ -24,10 +54,39 @@ describe("E2E", () => {
         const aatrox = await rAPI.ddragon.champion.byName({
           championName: "Aatrox",
         });
+
+        const aatroxImage: RiotAPITypes.DDragon.DDragonImageDTO = {
+          full: "Aatrox.png",
+          sprite: "champion0.png",
+          group: "champion",
+          x: 0,
+          y: 0,
+          w: 48,
+          h: 48,
+        };
+
         expect(aatrox.type).toEqual("champion");
         expect(aatrox.format).toEqual("standAloneComplex");
         expect(aatrox.data.Aatrox.id).toEqual("Aatrox");
+        expect(aatrox.data.Aatrox.image).toEqual(aatroxImage);
       });
     });
+  });
+  test("profileIcons", async () => {
+    const rAPI = new RiotAPI("XXXX");
+    const profileIcons = await rAPI.ddragon.profileIcons();
+    const profilIcon: RiotAPITypes.DDragon.DDragonImageWrapperDTO = {
+      id: 1000,
+      image: {
+        full: "1000.png",
+        sprite: "profileicon0.png",
+        group: "profileicon",
+        x: 96,
+        y: 0,
+        w: 48,
+        h: 48,
+      },
+    };
+    expect(profileIcons.data["1000"]).toEqual(profilIcon);
   });
 });

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -1754,16 +1754,13 @@ export namespace RiotAPITypes {
       data: { [key: string]: T };
     }
     export interface DDragonImageDTO {
-      id?: number; // Only really used for the ProfileIcon. Should we create an entire interface just for that or leave it here as an optional?
-      image: {
-        full: string;
-        sprite: string;
-        group: string;
-        x: number;
-        y: number;
-        w: number;
-        h: number;
-      };
+      full: string;
+      sprite: string;
+      group: string;
+      x: number;
+      y: number;
+      w: number;
+      h: number;
     }
 
     export interface DDragonMapDTO
@@ -1774,10 +1771,12 @@ export namespace RiotAPITypes {
       MapId: string;
       image: DDragonImageDTO;
     }
-
+    export interface DDragonImageWrapperDTO {
+      id: number;
+      image: DDragonImageDTO;
+    }
     export interface DDragonProfileIconDTO
-      extends DDragonDataWrapper<DDragonImageDTO> {}
-
+      extends DDragonDataWrapper<DDragonImageWrapperDTO> {}
     export interface DDragonSummonerSpellDTO
       extends DDragonDataWrapper<DDragonSummonerSpellDataDTO> {}
 


### PR DESCRIPTION
DDragon image interface is currently misalign with the Champion image structure.

## Dev notes

- I adapted the `DDragonImageDTO` to fit with Champion images
- I created the `DDragonImageWrapperDTO` used inside `DDragonProfileIconDTO` to keep the current good Profile image interface

## Preview

[Champion images structure](https://ddragon.leagueoflegends.com/cdn/11.23.1/data/en_US/champion/Aatrox.json)
```javascript
const aatroxImage: RiotAPITypes.DDragon.DDragonImageDTO = {
  full: "Aatrox.png",
  sprite: "champion0.png",
  group: "champion",
  x: 0,
  y: 0,
  w: 48,
  h: 48,
};
```

[Profile images structure](https://ddragon.leagueoflegends.com/cdn/11.23.1/data/en_US/profileicon.json)
```javascript
const profilIcon: RiotAPITypes.DDragon.DDragonImageWrapperDTO = {
  id: 1000,
  image: {
    full: "1000.png",
    sprite: "profileicon0.png",
    group: "profileicon",
    x: 96,
    y: 0,
    w: 48,
    h: 48,
  },
};
```