### PR TITLE
typing: Fix ioredis typing

### DIFF
--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -1,12 +1,12 @@
 import { PlatformId } from "@fightmegg/riot-rate-limiter";
-import Redis from "ioredis";
+import { RedisOptions } from "ioredis";
 
 export namespace RiotAPITypes {
   export interface Config {
     debug?: boolean;
     cache?: {
       cacheType: "local" | "ioredis";
-      client?: Redis.RedisOptions | string;
+      client?: RedisOptions | string;
       ttls?: {
         byMethod: { [key: string]: number };
       };

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,11 +1,11 @@
-import Redis from "ioredis";
+import { Redis, RedisOptions } from "ioredis";
 
 export class RedisCache {
-  readonly client: Redis.Redis;
+  readonly client: Redis;
   readonly keyPrefix: string = "fm-riot-api-";
 
-  constructor(redisClientOpts: Redis.RedisOptions | string) {
-    this.client = new Redis(redisClientOpts as Redis.RedisOptions);
+  constructor(redisClientOpts: RedisOptions | string) {
+    this.client = new Redis(redisClientOpts as RedisOptions);
   }
 
   async get<T>(key: string): Promise<T | null> {


### PR DESCRIPTION
I tried to use this with `tsc` compiler then it throws an error

```
'Redis' only refers to a type, but is being used as a namespace here.
```

this PR should fix the problem