### PR TITLE
Update Valorant MatchlistEntryDTO teamId -> queueId

### DIFF
--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -1884,7 +1884,7 @@ export namespace RiotAPITypes {
     export interface MatchlistEntryDTO {
       matchId: string;
       gameStartTimeMillis: number;
-      teamId: string;
+      queueId: string;
     }
 
     export interface RecentMatchesDTO {


### PR DESCRIPTION
The type for the MatchlistEntryDTO is wrong, teamId is queueId
![image](https://github.com/fightmegg/riot-api/assets/7498880/82606b3a-1ac8-42c5-89d3-6c7945a9f5e2)
