### PR TITLE
fix(types): match-v5 riotIdGameName

### DIFF
--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -821,7 +821,7 @@ export namespace RiotAPITypes {
       profileIcon: number;
       puuid: string;
       quadraKills: number;
-      riotIdName: string;
+      riotIdGameName: string;
       riotIdTagline: string;
       role: string;
       sightWardsBoughtInGame: number;


### PR DESCRIPTION
The `riotIdName` field does not exist in the Match V5 API response.  
According to the official Riot Games API documentation, the correct field is `riotIdGameName`.
This change updates the type definition to match the actual API response.

Official docs: https://developer.riotgames.com/apis#match-v5/GET_getMatchIdsByPUUID
